### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,4 +27,4 @@ byte-buffer for Python.
 
 ``zero_buffer`` works on Python 2.6, 2.7, 3.2, 3.3, and PyPy.
 
-.. _`Documentation`: https://zero-buffer.readthedocs.org/en/latest/
+.. _`Documentation`: https://zero-buffer.readthedocs.io/en/latest/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.